### PR TITLE
WL-3882 Cope with incomplete data from DB.

### DIFF
--- a/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/StrippedReportDef.java
+++ b/sitestats-tool/src/java/org/sakaiproject/sitestats/tool/entityproviders/StrippedReportDef.java
@@ -43,8 +43,14 @@ public class StrippedReportDef {
         this.title = reportDef.getTitle();
         this.description = reportDef.getDescription();
         ReportParams params = reportDef.getReportParams();
-        this.from = params.getWhenFrom().getTime();
-        this.to = params.getWhenTo().getTime();
+        // The report parameters might not all be defined and so there may not be a
+        // from / to value.
+        if (params.getWhenFrom() != null) {
+            this.from = params.getWhenFrom().getTime();
+        }
+        if (params.getWhenTo() != null) {
+            this.to = params.getWhenTo().getTime();
+        }
         this.toolIds = params.getWhatToolIds();
         this.eventIds = params.getWhatEventIds();
         this.resourceIds = params.getWhatResourceIds();


### PR DESCRIPTION
When loading report parameters from the database they may not be complete so we shouldn’t assume that any fields are populated. Copying across null values is fine, but we can’t call anything on them.
